### PR TITLE
Add support for PIL.

### DIFF
--- a/unity_launcher_folders/generateIcon.py
+++ b/unity_launcher_folders/generateIcon.py
@@ -14,7 +14,11 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 ### END LICENSE
 from gi.repository import Gdk, GdkPixbuf
-import Image
+
+try:
+    import Image
+except:
+    from PIL.Image import core as Image
 import os
 
 CONFIG_DIR = os.getenv('HOME') + "/.appDrawerConfig/"


### PR DESCRIPTION
I downloaded and tried to run the unity-launcher-folders application but I was getting an error:

```
:~$ unity-launcher-folders
/usr/lib/python2.7/dist-packages/unity_launcher_folders/__init__.py:21: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk, Gdk, GdkPixbuf, Pango, Gio
Traceback (most recent call last):
  File "/usr/bin/unity-launcher-folders", line 46, in <module>
    import unity_launcher_folders
  File "/usr/lib/python2.7/dist-packages/unity_launcher_folders/__init__.py", line 23, in <module>
    from generateIcon import GenerateIcon
  File "/usr/lib/python2.7/dist-packages/unity_launcher_folders/generateIcon.py", line 17, in <module>
    import Image
ImportError: No module named Image
```

I installed Pillow via pip but I was still getting this message. PIL is no longer supported. Changing the import to support Pillow worked flawlessly.
